### PR TITLE
Added test cases for all scenarios in request handler.

### DIFF
--- a/lib/requesthandler.js
+++ b/lib/requesthandler.js
@@ -50,10 +50,11 @@ Request.prototype.request = function (method, path, data, expectedStatus, callba
   });
 
   req.on('socket', function (socket) {
-    if (options.timeout) {
-      socket.setTimeout(options.timeout);
+    if (self.options.timeout) {
+      socket.setTimeout(self.options.timeout);
       socket.on('timeout', function () {
         req.abort();
+        callback(new Error('Request timed out.'));
       });
     }
   });

--- a/test/requesthandler.test.js
+++ b/test/requesthandler.test.js
@@ -87,7 +87,7 @@ describe('Request', function () {
 
   });
 
-  describe('GET http request', function () {
+  describe('request with no request body', function () {
 
     var options;
     var expectedAuth;
@@ -96,23 +96,24 @@ describe('Request', function () {
     var data;
     var expectedStatus;
     var callbackSpy;
-    var httpRequestStub;
+    var requestStub;
     var querystring;
+    var expectedPath;
+    var responseBody;
     var requestFake;
     var responseFake;
     var responseHandlerFake;
+    var stringifyStub;
 
     before(function () {
       options = {
         host: 'some host',
         port: 6677,
-        https: false,
+        https: true,
         timeout: 321,
         username: 'user@host.com',
         password: 'wildermuth'
       };
-
-      expectedAuth = options.username + ':' + options.password;
 
       method = 'BAM';
       path = '/some/path';
@@ -120,23 +121,29 @@ describe('Request', function () {
       expectedStatus = 435;
       callbackSpy = sinon.spy();
       querystring = 'asdljhasdkljalkdjs';
+      expectedPath = path + '?' + querystring;
+      responseBody = 'This was the response body';
 
-      requestFake = { on: sinon.spy(), end: sinon.spy() };
-      responseFake = { on: sinon.spy() };
+      expectedAuth = options.username + ':' + options.password;
 
-      httpRequestStub = sinon.stub();
-      httpRequestStub.callsArgWith(1, responseFake);
-      httpRequestStub.returns(requestFake);
+      var socketFake = { setTimeout: sinon.stub(), on: sinon.stub() };
 
-      var httpFake = { request: httpRequestStub };
+      requestFake = { on: sinon.stub(), end: sinon.spy() };
+      requestFake.on.withArgs('socket').callsArgWith(1, socketFake);
 
-      var stringifyStub = sinon.stub().returns(querystring);
-      var querystringFake = { stringify: stringifyStub };
-      responseHandlerFake = { handle: sinon.stub().callsArg(2) };
+      responseFake = 'This is a fake response object';
+
+      requestStub = sinon.stub();
+      requestStub.callsArgWith(1, responseFake);
+      requestStub.returns(requestFake);
+
+      responseHandlerFake = { handle: sinon.stub().callsArgWith(2, null, responseBody) };
+
+      stringifyStub = sinon.stub().returns(querystring);
 
       var requireStub = sinon.stub();
-      requireStub.withArgs('http').returns(httpFake);
-      requireStub.withArgs('querystring').returns(querystringFake);
+      requireStub.withArgs('https').returns({ request: requestStub });
+      requireStub.withArgs('querystring').returns({ stringify: stringifyStub });
       requireStub.withArgs('./responsehandler').returns(responseHandlerFake);
 
       var request = RequestHandler(options, requireStub);
@@ -144,47 +151,258 @@ describe('Request', function () {
     });
 
     it('should call http.request once', function () {
-      sinon.assert.calledOnce(httpRequestStub);
+      sinon.assert.calledOnce(requestStub);
     });
 
-    it('should call http.request with the expected host', function () {
-      sinon.assert.calledWith(httpRequestStub, sinon.match({ host: options.host }));
+    it('should stringify the query string', function () {
+      sinon.assert.calledWith(stringifyStub, data);
     });
 
-    it('should call http.request with the expected port', function () {
-      sinon.assert.calledWith(httpRequestStub, sinon.match({ port: options.port }));
-    });
-
-    it('should call http.request with the expected path', function () {
-      sinon.assert.calledWith(httpRequestStub, sinon.match({ path: path + '?' + querystring }));
-    });
-
-    it('should call http.request with the expected method', function () {
-      sinon.assert.calledWith(httpRequestStub, sinon.match({ method: method }));
-    });
-
-    it('should call http.request with the expected auth', function () {
-      sinon.assert.calledWith(httpRequestStub, sinon.match({ auth: expectedAuth }));
+    it('should call http.request with the expected options', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({ 
+        host: options.host,
+        port: options.port,
+        path: expectedPath,
+        method: method,
+        auth: expectedAuth
+      }));
     });
 
     it('should call http.request with the expected headers', function () {
-      sinon.assert.calledWith(httpRequestStub, sinon.match({ headers: {
+      sinon.assert.calledWith(requestStub, sinon.match({ headers: {
         'Accept': 'application/xml',
         'User-Agent': 'github.com/codesleuth/esendex-node'
       }}));
     });
 
-    it('should call end on the request', function () {
+    it('should end the request', function () {
       sinon.assert.calledOnce(requestFake.end);
     });
 
-    it('should call the response handler', function () {
+    it('should call the response handler to handle the response', function () {
       sinon.assert.calledOnce(responseHandlerFake.handle);
-      sinon.assert.calledWith(responseHandlerFake.handle, responseFake, expectedStatus, callbackSpy);
+      sinon.assert.calledWith(responseHandlerFake.handle, responseFake, expectedStatus, sinon.match.func);
     });
 
-    it('should call the callback', function () {
+    it('should have called the callback', function () {
       sinon.assert.calledOnce(callbackSpy);
+      sinon.assert.calledWith(callbackSpy, null, responseBody);
+    });
+
+  });
+
+  describe('POST request with a request body', function () {
+
+    var path;
+    var body;
+    var responseBody;
+    var requestFake;
+    var requestStub;
+    var responseHandlerFake;
+    var callbackSpy;
+
+    before(function () {
+      path = '1/2/3/4';
+      body = 'some xml body';
+      responseBody = 'This is the response body content';
+
+      requestFake = { on: sinon.stub(), end: sinon.stub(), write: sinon.spy() };
+
+      requestStub = sinon.stub().callsArg(1).returns(requestFake);
+      responseHandlerFake = { handle: sinon.stub().callsArgWith(2, null, responseBody) };
+
+      var requireStub = sinon.stub();
+      requireStub.withArgs('https').returns({ request: requestStub, on: sinon.stub() });
+      requireStub.withArgs('./responsehandler').returns(responseHandlerFake);
+
+      callbackSpy = sinon.spy();
+
+      var request = RequestHandler(null, requireStub);
+      request.request('POST', path, body, 798, callbackSpy);
+    });
+
+    it('should call the request with the POST method option', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({ method: 'POST' }));
+    });
+
+    it('should call the request with an unmodified path option', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({ path: path }));
+    });
+
+    it('should call the request with body specific headers', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({
+        headers: {
+          'Content-Type': 'application/xml',
+          'Content-Length': body.length
+      }}));
+    });
+
+    it('should write the request body to the request', function () {
+      sinon.assert.calledOnce(requestFake.write);
+      sinon.assert.calledWith(requestFake.write, body);
+    });
+
+    it('should have called the callback', function () {
+      sinon.assert.calledOnce(callbackSpy);
+      sinon.assert.calledWith(callbackSpy, null, responseBody);
+    });
+
+  });
+
+  describe('PUT request with a request body', function () {
+
+    var path;
+    var body;
+    var responseBody;
+    var requestFake;
+    var requestStub;
+    var responseHandlerFake;
+    var callbackSpy;
+
+    before(function () {
+      path = 'who/do/we/appreciate';
+      body = 'I am xml body';
+      responseBody = 'I am response body';
+
+      requestFake = { on: sinon.stub(), end: sinon.stub(), write: sinon.spy() };
+
+      requestStub = sinon.stub().callsArg(1).returns(requestFake);
+      responseHandlerFake = { handle: sinon.stub().callsArgWith(2, null, responseBody) };
+
+      var requireStub = sinon.stub();
+      requireStub.withArgs('https').returns({ request: requestStub, on: sinon.stub() });
+      requireStub.withArgs('./responsehandler').returns(responseHandlerFake);
+
+      callbackSpy = sinon.spy();
+
+      var request = RequestHandler(null, requireStub);
+      request.request('PUT', path, body, 3132, callbackSpy);
+    });
+
+    it('should call the request with the POST method option', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({ method: 'PUT' }));
+    });
+
+    it('should call the request with an unmodified path option', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({ path: path }));
+    });
+
+    it('should call the request with body specific headers', function () {
+      sinon.assert.calledWith(requestStub, sinon.match({
+        headers: {
+          'Content-Type': 'application/xml',
+          'Content-Length': body.length
+      }}));
+    });
+
+    it('should write the request body to the request', function () {
+      sinon.assert.calledOnce(requestFake.write);
+      sinon.assert.calledWith(requestFake.write, body);
+    });
+
+    it('should have called the callback', function () {
+      sinon.assert.calledOnce(callbackSpy);
+      sinon.assert.calledWith(callbackSpy, null, responseBody);
+    });
+
+  });
+
+  describe('request with a request error', function () {
+
+    var requestError;
+    var requestFake;
+    var callbackSpy;
+
+    before(function () {
+      requestError = 'an error';
+
+      requestFake = { on: sinon.stub(), end: sinon.stub() };
+      requestFake.on.withArgs('error').callsArgWith(1, requestError);
+
+      var requestStub = sinon.stub().returns(requestFake);
+
+      var requireStub = sinon.stub();
+      requireStub.withArgs('https').returns({ request: requestStub, on: sinon.stub() });
+      requireStub.withArgs('querystring').returns({ stringify: sinon.stub() });
+      requireStub.withArgs('./responsehandler').returns(null);
+
+      callbackSpy = sinon.spy();
+
+      var request = RequestHandler(null, requireStub);
+      request.request('PLOP', '/path', {}, 3132, callbackSpy);
+    });
+
+    it('should have called the callback with the expected error', function () {
+      sinon.assert.calledOnce(callbackSpy);
+      sinon.assert.calledWith(callbackSpy, requestError);
+    });
+
+  });
+
+  describe('request with socket timeout', function () {
+
+    var timeout;
+    var socketFake;
+    var requestFake;
+    var callbackSpy;
+
+    before(function () {
+      timeout = 243;
+
+      socketFake = { setTimeout: sinon.spy(), on: sinon.stub() };
+      socketFake.on.withArgs('timeout').callsArg(1);
+
+      requestFake = { on: sinon.stub(), end: sinon.stub(), abort: sinon.expectation.create().once() };
+      requestFake.on.withArgs('socket').callsArgWith(1, socketFake);
+
+      var requestStub = sinon.stub().returns(requestFake);
+
+      var requireStub = sinon.stub();
+      requireStub.withArgs('https').returns({ request: requestStub, on: sinon.stub() });
+      requireStub.withArgs('querystring').returns({ stringify: sinon.stub() });
+      requireStub.withArgs('./responsehandler').returns(null);
+
+      callbackSpy = sinon.spy();
+
+      var request = RequestHandler({ timeout: timeout }, requireStub);
+      request.request('asdkj', '/290348nj', {}, 215, callbackSpy);
+    });
+
+    it('should have set a socket timeout value', function () {
+      sinon.assert.calledWith(socketFake.setTimeout, timeout);
+    });
+
+    it('should have set a socket timeout event which calls abort', function () {
+      sinon.assert.calledWith(socketFake.on, 'timeout');
+      requestFake.abort.verify();
+    });
+
+    it('should have called the callback with a timeout error', function () {
+      sinon.assert.calledOnce(callbackSpy);
+      sinon.assert.calledWith(callbackSpy, sinon.match.instanceOf(Error));
+    });
+
+  });
+
+  describe('request with https disabled', function () {
+
+    var requestStub;
+
+    before(function () {
+      var requestFake = { on: sinon.stub(), end: sinon.stub(), write: sinon.stub() };
+
+      requestStub = sinon.stub().returns(requestFake);
+
+      var requireStub = sinon.stub();
+      requireStub.withArgs('http').returns({ request: requestStub, on: sinon.stub() });
+      requireStub.withArgs('./responsehandler').returns(null);
+
+      var request = RequestHandler({ https: false }, requireStub);
+      request.request('PUT', '/290348nj', {}, 215, sinon.spy());
+    });
+
+    it('should have called request on the http module', function () {
+      sinon.assert.calledOnce(requestStub);
     });
 
   });


### PR DESCRIPTION
_According to [coveralls.io](https://coveralls.io/r/Codesleuth/esendex-node), the code has 100% coverage._

This work was done to increase the coverage for the requesthandler module, but I know that the callbacks for errors in the higher level modules are not tested. This is probably a side effect from something to do with the coverage client being used ([istanbul](https://github.com/gotwarlost/istanbul)) so more work has yet to be done to resolve that.
