### PR TITLE
Switching to Esandex sandbox for integration testing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "xml2js": "0.4.4"
   },
   "devDependencies": {
-    "esendex-sandbox": "codesleuth/esendex-sandbox",
     "coveralls": "^2.11.1",
+    "esandex": "~0.0.3",
     "gulp": "^3.8.8",
     "gulp-jshint": "^1.8.4",
     "gulp-mocha": "^0.5.2",

--- a/test/integration/accounts.integration.test.js
+++ b/test/integration/accounts.integration.test.js
@@ -1,6 +1,6 @@
 var assert = require('assert'),
     util = require('util'),
-    esendexSandbox = require('esendex-sandbox'),
+    esandex = require('esandex'),
     Esendex = require('../../');
 
 describe('Accounts Integration', function () {
@@ -10,7 +10,7 @@ describe('Accounts Integration', function () {
 
   before(function (done) {
     var sandboxPort = process.env.PORT || 3000;
-    var sandboxApp = esendexSandbox.create();
+    var sandboxApp = esandex.create();
 
     setTimeout(function () {
       sandbox = sandboxApp.listen(sandboxPort, function () {

--- a/test/integration/messages.integration.test.js
+++ b/test/integration/messages.integration.test.js
@@ -1,6 +1,6 @@
 var assert = require('assert'),
     util = require('util'),
-    esendexSandbox = require('esendex-sandbox'),
+    esandex = require('esandex'),
     Esendex = require('../../');
 
 describe('Messages Integration', function () {
@@ -10,7 +10,7 @@ describe('Messages Integration', function () {
 
   before(function (done) {
     var sandboxPort = process.env.PORT || 3000;
-    var sandboxApp = esendexSandbox.create();
+    var sandboxApp = esandex.create();
 
     setTimeout(function () {
       sandbox = sandboxApp.listen(sandboxPort, function () {


### PR DESCRIPTION
The previous `esendex-sandbox` package has been published under a new name: _[esandex](https://www.npmjs.org/package/esandex)_

This pull request introduces that package. It technically fixes a bug, since the old sandbox location is gone.
