### PR TITLE
Support Unicode message bodies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "editor.tabSize": 2
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "David Wood <david.p.wood@gmail.com> (http://www.codesleuth.co.uk/)",
   "license": "(MIT OR BSD-3-Clause)",
   "dependencies": {
-    "xml2js": "^0.4.15"
+    "xml2js": "codesleuth/node-xml2js#62554a7"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",

--- a/src/lib/requesthandler.ts
+++ b/src/lib/requesthandler.ts
@@ -56,10 +56,13 @@ export class RequestHandler {
       headers: headers,
       auth: this.options.username + ':' + this.options.password
     };
+    
+    var dataBuf: Buffer;
   
     if (isPost) {
+      dataBuf = data ? new Buffer(data, 'utf8') : null;
       headers['Content-Type'] = 'application/xml';
-      headers['Content-Length'] = data ? data.length : 0;
+      headers['Content-Length'] = data ? dataBuf.length : 0;
     }
   
     var proto = this.options.https ? https : http;
@@ -81,7 +84,7 @@ export class RequestHandler {
       callback(err);
     });
   
-    if (isPost && data) req.write(data);
+    if (isPost && data) req.write(dataBuf);
     req.end();
   }
 }

--- a/src/lib/xmlbuilder.ts
+++ b/src/lib/xmlbuilder.ts
@@ -10,7 +10,8 @@ export class XmlBuilder {
         standalone: null,
         version: '1.0',
         encoding: 'UTF-8'
-      }
+      },
+      allowSurrogateChars: true
     });
   }
   

--- a/src/test/messages.integration.test.ts
+++ b/src/test/messages.integration.test.ts
@@ -94,7 +94,48 @@ describe('Messages Integration', function () {
         accountreference: 'EX0123456',
         message: [{
           to: '447000000000',
-          body: "Every message matters!"
+          body: 'Every message matters!'
+        }]
+      };
+
+      esendex.messages.send(messages, function (err, res) {
+        if (err) return done(err);
+        response = res;
+        loggedRequest = esendexFake.dispatcherRequests.length === 0 ? null :  esendexFake.dispatcherRequests[0];
+        done();
+      });
+    });
+
+    it('should return the batch ID of the sent message', function () {
+      assert.strictEqual(response.batchid, 'F8BF9867-FF81-49E4-ACC5-774DE793B776');
+    });
+
+    it('should return the messageheader ID and uri of the sent message', function () {
+      assert.strictEqual(response.messageheader[0].id, '1183C73D-2E62-4F60-B610-30F160BDFBD5');
+      assert.strictEqual(response.messageheader[0].uri, 'https://api.esendex.com/v1.0/messageheaders/1183C73D-2E62-4F60-B610-30F160BDFBD5');
+    });
+
+    it('should return an array of sent message headers', function () {
+      assert.ok(isArray(response.messageheader));
+    });
+
+    it('should return one sent message header', function () {
+      assert.strictEqual(response.messageheader.length, 1);
+    });
+  });
+
+  describe('send a unicode message', function () {
+
+    var response;
+    var loggedRequest;
+
+    before(function (done) {
+      var messages = {
+        accountreference: 'EX0123456',
+        characterset: 'Unicode',
+        message: [{
+          to: '447000000000',
+          body: 'Every 🐳 matters!'
         }]
       };
 

--- a/src/test/requesthandler.test.ts
+++ b/src/test/requesthandler.test.ts
@@ -202,6 +202,7 @@ describe('RequestHandler', function () {
 
     var path;
     var body;
+    var bodyLength;
     var responseBody;
     var requestFake;
     var requestStub;
@@ -209,10 +210,11 @@ describe('RequestHandler', function () {
 
     before(function () {
       path = '1/2/3/4';
-      body = 'some xml body';
+      body = 'some unicode xml 🐳 body';
+      bodyLength = 26;
       responseBody = 'This is the response body content';
 
-      requestFake = { on: sinon.stub(), end: sinon.stub(), write: sinon.expectation.create().once() };
+      requestFake = { on: sinon.stub(), end: sinon.stub(), write: sinon.spy() };
 
       requestStub = sinon.stub().callsArg(1).returns(requestFake);
       
@@ -244,12 +246,13 @@ describe('RequestHandler', function () {
       sinon.assert.calledWith(requestStub, sinon.match({
         headers: {
           'Content-Type': 'application/xml',
-          'Content-Length': body.length
+          'Content-Length': bodyLength
       }}));
     });
 
-    it('should write the request body to the request', function () {
-      sinon.assert.calledWith(requestFake.write, body);
+    it('should write the request body buffer to the request', function () {
+      sinon.assert.calledOnce(requestFake.write);
+      assert.equal(requestFake.write.args[0].toString('utf8'), body);
     });
 
     it('should have called the callback', function () {
@@ -366,8 +369,9 @@ describe('RequestHandler', function () {
       }}));
     });
 
-    it('should write the request body to the request', function () {
-      sinon.assert.calledWith(requestFake.write, body);
+    it('should write the request body buffer to the request', function () {
+      sinon.assert.calledOnce(requestFake.write);
+      assert.equal(requestFake.write.args[0].toString('utf8'), body);
     });
 
     it('should have called the callback', function () {

--- a/src/test/xmlbuilder.test.ts
+++ b/src/test/xmlbuilder.test.ts
@@ -38,7 +38,8 @@ describe('XmlBuilder', function () {
         standalone: null,
         version: '1.0',
         encoding: 'UTF-8'
-      }
+      },
+      allowSurrogateChars: true
     }));
   });
   

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "sourceMaps": true
+    "sourceMap": true
   }
 }

--- a/src/typings/xml2js/xml2js.d.ts
+++ b/src/typings/xml2js/xml2js.d.ts
@@ -45,6 +45,7 @@ declare module 'xml2js' {
             renderOpts?: RenderOptions;
             rootName?: string;
             xmldec?: XMLDeclarationOptions;
+            allowSurrogateChars?: boolean
         }
 
         interface Options {


### PR DESCRIPTION
The xml2js dependency does not allow passing through the `allowSurrogateChars` option to the underlying builder. This change uses a fork of the package which does pass through the option, and ultimately adds support for Unicode characters when producing the XML body of a dispatcher request.

See: https://github.com/Leonidas-from-XIV/node-xml2js/pull/266