### PR TITLE
Update xml2js to official npm package, see #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "David Wood <david.p.wood@gmail.com> (http://www.codesleuth.co.uk/)",
   "license": "(MIT OR BSD-3-Clause)",
   "dependencies": {
-    "xml2js": "codesleuth/node-xml2js#62554a7"
+    "xml2js": "^0.4.16"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
The build from pull request Leonidas-from-XIV/node-xml2js#266 has been pushed to NPM.
This update uses the latest official build of the dependency.